### PR TITLE
Preprocess example files to deal with `from __future__` imports

### DIFF
--- a/generate_notebooks.py
+++ b/generate_notebooks.py
@@ -40,8 +40,12 @@ def split_code(code):
             if line.startswith('from __future__ import'):
                 future_imports.append(line)
             elif line.startswith("'''") or line.startswith('"""'):
-                in_multiline_comment = True
-                docstring.append(line[3:])
+                if line.endswith("'''") or line.endswith('"""'):
+                    # Triple quoted single line docstring
+                    docstring.append(line[3:-3])
+                else:
+                    in_multiline_comment = True
+                    docstring.append(line[3:])
             else:
                 # Neither `from __future__` import nor docstring --> the rest
                 # is the main code of the example

--- a/generate_notebooks.py
+++ b/generate_notebooks.py
@@ -22,7 +22,7 @@ def split_code(code):
     other_code = []
     for line in code.split('\n'):
         line = line.rstrip()
-        if len(line) == 0:
+        if len(line) == 0 and not in_multiline_comment:
             continue
         if re.match(r'^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)', line) is not None:
             continue


### PR DESCRIPTION
Also put docstring into a markdown cell

This should fix the issue with `%matplotlib notebook` and `from __future__` imports, as well as leading to somewhat more nicely formatted code (docstring in a markdown cell, removal of useless comments like `#!/usr/bin/env python`).